### PR TITLE
Fixed redirect to correct plan.

### DIFF
--- a/client-only/client/index.html
+++ b/client-only/client/index.html
@@ -104,7 +104,7 @@
         // with the current quantity
         stripe
           .redirectToCheckout({
-            items: [{ plan: SUBSCRIPTION_BASIC_PLAN_ID, quantity: 1 }],
+            items: [{ plan: planId, quantity: 1 }],
             successUrl:
               DOMAIN + "/success.html?session_id={CHECKOUT_SESSION_ID}",
             cancelUrl: DOMAIN + "/canceled.html"


### PR DESCRIPTION
The client-only example subscribe buttons both redirect to the basic plan. I changed the redirectToCheckout function so that the items plan value now accepts the correct variable.