### PR TITLE
Add Customer Portal Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,11 @@ DOMAIN=http://localhost:4242
 BASIC_PRICE_ID=price_12345
 PRO_PRICE_ID=price_67890
 
+# The authenticated customers ID,
+# In practice this will come from your database.
+CUSTOMER=cus_abc123
+
 # Environment
 STATIC_DIR=../../client
+
+

--- a/client/success.html
+++ b/client/success.html
@@ -25,12 +25,16 @@
           <div class="sr-section completed-view">
             <div class="sr-callout">
               <pre>
-    
+
               </pre>
             </div>
             <button onclick="window.location.href = '/';">Restart demo</button>
-          </div> 
-        </div> 
+
+            <form action="/customer-portal" method="post">
+              <button>Manage Billing</button>
+            </form>
+          </div>
+        </div>
         <div class="sr-content">
         <div class="pasha-image-stack">
           <img

--- a/server/dotnet/Configuration/StripeOptions.cs
+++ b/server/dotnet/Configuration/StripeOptions.cs
@@ -7,4 +7,5 @@
     public string BasicPrice { get; set; }
     public string ProPrice { get; set; }
     public string Domain { get; set; }
+    public string Customer { get; set; }
 }

--- a/server/dotnet/Controllers/PaymentsController.cs
+++ b/server/dotnet/Controllers/PaymentsController.cs
@@ -52,6 +52,7 @@ namespace server.Controllers
                         Quantity = 1,
                     },
                 },
+                Customer = this.options.Value.Customer,
             };
             var service = new SessionService(this.client);
             try
@@ -81,6 +82,21 @@ namespace server.Controllers
             var service = new SessionService(this.client);
             var session = await service.GetAsync(sessionId);
             return Ok(session);
+        }
+
+        [HttpPost("customer-portal")]
+        public async Task<IActionResult> CustomerPortal()
+        {
+            var options = new Stripe.BillingPortal.SessionCreateOptions
+            {
+                // This ID is typically stored with the authenticated
+                // user in your database.
+                Customer = this.options.Value.Customer,
+                ReturnUrl = this.options.Value.Domain,
+            };
+            var service = new Stripe.BillingPortal.SessionService(this.client);
+            var session = await service.CreateAsync(options);
+            return Redirect(session.Url);
         }
 
         [HttpPost("webhook")]

--- a/server/dotnet/Controllers/PaymentsController.cs
+++ b/server/dotnet/Controllers/PaymentsController.cs
@@ -34,6 +34,12 @@ namespace server.Controllers
         [HttpPost("create-checkout-session")]
         public async Task<IActionResult> CreateCheckoutSession([FromBody] CreateCheckoutSessionRequest req)
         {
+            // This ID is typically stored with the authenticated user in your database. For
+            // demonstration purposes, we're pulling this value from environment variables.
+            //
+            // Note this is not required to create a Subscription, but demonstrates how you would
+            // create a new Subscription using Stripe Checkout with an existing user.
+            var stripeCustomerId = this.options.Value.Customer;
 
             var options = new SessionCreateOptions
             {
@@ -52,7 +58,7 @@ namespace server.Controllers
                         Quantity = 1,
                     },
                 },
-                Customer = this.options.Value.Customer,
+                Customer = stripeCustomerId,
             };
             var service = new SessionService(this.client);
             try
@@ -87,15 +93,23 @@ namespace server.Controllers
         [HttpPost("customer-portal")]
         public async Task<IActionResult> CustomerPortal()
         {
+            // This ID is typically stored with the authenticated
+            // user in your database. For demonstration purposes, we're
+            // pulling this value from environment variables.
+            var stripeCustomerId = this.options.Value.Customer;
+
+            // This is the URL to which your customer will return after
+            // they are done managing billing in the Customer Portal.
+            var returnUrl = this.options.Value.Domain;
+
             var options = new Stripe.BillingPortal.SessionCreateOptions
             {
-                // This ID is typically stored with the authenticated
-                // user in your database.
-                Customer = this.options.Value.Customer,
-                ReturnUrl = this.options.Value.Domain,
+                Customer = stripeCustomerId,
+                ReturnUrl = returnUrl,
             };
             var service = new Stripe.BillingPortal.SessionService(this.client);
             var session = await service.CreateAsync(options);
+
             return Redirect(session.Url);
         }
 

--- a/server/dotnet/Startup.cs
+++ b/server/dotnet/Startup.cs
@@ -32,6 +32,7 @@ namespace server
                 options.BasicPrice = Environment.GetEnvironmentVariable("BASIC_PRICE_ID");
                 options.ProPrice = Environment.GetEnvironmentVariable("PRO_PRICE_ID");
                 options.Domain = Environment.GetEnvironmentVariable("DOMAIN");
+                options.Customer = Environment.GetEnvironmentVariable("CUSTOMER");
             });
 
             services.AddControllersWithViews().AddNewtonsoftJson(options =>

--- a/server/dotnet/server.sln
+++ b/server/dotnet/server.sln
@@ -1,7 +1,7 @@
 
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "server", "server.csproj", "{A5BE002D-4BA4-4611-B86E-87602A060827}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "server", "server.csproj", "{8756F1D9-F873-4095-AD89-5F7D4029A8A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -9,9 +9,9 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A5BE002D-4BA4-4611-B86E-87602A060827}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A5BE002D-4BA4-4611-B86E-87602A060827}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A5BE002D-4BA4-4611-B86E-87602A060827}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A5BE002D-4BA4-4611-B86E-87602A060827}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8756F1D9-F873-4095-AD89-5F7D4029A8A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8756F1D9-F873-4095-AD89-5F7D4029A8A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8756F1D9-F873-4095-AD89-5F7D4029A8A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8756F1D9-F873-4095-AD89-5F7D4029A8A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/stripe/stripe-go/v71"
-	"github.com/stripe/stripe-go/v71/checkout/session"
 	portalsession "github.com/stripe/stripe-go/v71/billingportal/session"
+	"github.com/stripe/stripe-go/v71/checkout/session"
 	"github.com/stripe/stripe-go/v71/webhook"
 )
 
@@ -41,90 +41,106 @@ func handleSetup(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, struct {
 		PublishableKey string `json:"publishableKey"`
-		BasicPrice string `json:"basicPrice"`
-		ProPrice string `json:"proPrice"`
+		BasicPrice     string `json:"basicPrice"`
+		ProPrice       string `json:"proPrice"`
 	}{
 		PublishableKey: os.Getenv("STRIPE_PUBLISHABLE_KEY"),
-		BasicPrice: os.Getenv("BASIC_PRICE_ID"),
-		ProPrice: os.Getenv("PRO_PRICE_ID"),
+		BasicPrice:     os.Getenv("BASIC_PRICE_ID"),
+		ProPrice:       os.Getenv("PRO_PRICE_ID"),
 	})
 }
 
 func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
-  if r.Method != "POST" {
-    http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-    return
-  }
+	if r.Method != "POST" {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
 
-  var req struct {
-    Price string `json:"priceId"`
-  }
-  if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-    http.Error(w, err.Error(), http.StatusInternalServerError)
-    log.Printf("json.NewDecoder.Decode: %v", err)
-    return
-  }
+	var req struct {
+		Price string `json:"priceId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("json.NewDecoder.Decode: %v", err)
+		return
+	}
 
-  params := &stripe.CheckoutSessionParams{
-    SuccessURL: stripe.String(os.Getenv("DOMAIN") + "/success.html?session_id={CHECKOUT_SESSION_ID}"),
-    CancelURL: stripe.String(os.Getenv("DOMAIN") + "/cancel.html"),
-    PaymentMethodTypes: stripe.StringSlice([]string{
-      "card",
-    }),
-    Mode: stripe.String(string(stripe.CheckoutSessionModeSubscription)),
-    LineItems: []*stripe.CheckoutSessionLineItemParams{
-      &stripe.CheckoutSessionLineItemParams{
-        Price: stripe.String(req.Price),
-        Quantity: stripe.Int64(1),
-      },
-    },
+	// This is the ID of the Stripe Customer.  Typically you'll create the
+	// customer object When the user signs up for your service and you can pull
+	// this out of the database with the authenticated user.
+	//
+	// Note: The customer param is not strictly required for creating a subscription
+	// this demonstrates how you might create a subscription associated with
+	// an existing Stripe Customer object.
+	stripeCustomerID := os.Getenv("CUSTOMER")
 
-    // This is the ID of the Stripe Customer.  Typically you'll create the
-    // customer object When the user signs up for your service and you can pull
-    // this out of the database with the authenticated user.
-    Customer: stripe.String(os.Getenv("CUSTOMER")),
-  }
+	params := &stripe.CheckoutSessionParams{
+		SuccessURL: stripe.String(os.Getenv("DOMAIN") + "/success.html?session_id={CHECKOUT_SESSION_ID}"),
+		CancelURL:  stripe.String(os.Getenv("DOMAIN") + "/cancel.html"),
+		PaymentMethodTypes: stripe.StringSlice([]string{
+			"card",
+		}),
+		Mode: stripe.String(string(stripe.CheckoutSessionModeSubscription)),
+		LineItems: []*stripe.CheckoutSessionLineItemParams{
+			&stripe.CheckoutSessionLineItemParams{
+				Price:    stripe.String(req.Price),
+				Quantity: stripe.Int64(1),
+			},
+		},
+		Customer: stripe.String(stripeCustomerID),
+	}
 
-  s, err := session.New(params)
-  if err != nil {
-    w.WriteHeader(http.StatusBadRequest)
-    writeJSON(w, struct {
-      ErrorData string `json:"error"`
-    }{
-      ErrorData: "test",
-    })
-    return
-  }
+	s, err := session.New(params)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, struct {
+			ErrorData string `json:"error"`
+		}{
+			ErrorData: "test",
+		})
+		return
+	}
 
-  writeJSON(w, struct {
-    SessionID string `json:"sessionId"`
-  }{
-    SessionID: s.ID,
-  })
+	writeJSON(w, struct {
+		SessionID string `json:"sessionId"`
+	}{
+		SessionID: s.ID,
+	})
 }
 
 func handleCheckoutSession(w http.ResponseWriter, r *http.Request) {
-  if r.Method != "GET" {
-    http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-    return
-  }
-  sessionID := r.URL.Query().Get("sessionId")
-  s, _ := session.Get(sessionID, nil)
-  writeJSON(w, s)
+	if r.Method != "GET" {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	sessionID := r.URL.Query().Get("sessionId")
+	s, _ := session.Get(sessionID, nil)
+	writeJSON(w, s)
 }
 
 func handleCustomerPortal(w http.ResponseWriter, r *http.Request) {
-  if r.Method != "POST" {
-    http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-    return
-  }
-  params := &stripe.BillingPortalSessionParams{
-    Customer: stripe.String(os.Getenv("CUSTOMER")),
-    ReturnURL: stripe.String(os.Getenv("DOMAIN")),
-  }
-  s, _ := portalsession.New(params)
+	if r.Method != "POST" {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
 
-  http.Redirect(w, r, s.URL, 302)
+	// This is the ID of the Stripe Customer and is typically stored in your
+	// database and would be retrieved along with the currently authenticated
+	// user. For demonstration, we're storing this value in the environment
+	// variables.
+	stripeCustomerID := os.Getenv("CUSTOMER")
+
+	// The URL to which the user is redirected when they are done managing
+	// billing in the portal.
+	returnURL := os.Getenv("DOMAIN")
+
+	params := &stripe.BillingPortalSessionParams{
+		Customer:  stripe.String(stripeCustomerID),
+		ReturnURL: stripe.String(returnURL),
+	}
+	s, _ := portalsession.New(params)
+
+	http.Redirect(w, r, s.URL, 302)
 }
 
 func handleWebhook(w http.ResponseWriter, r *http.Request) {

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -35,6 +35,14 @@ app.post("/create-checkout-session", async (req, res) => {
   const domainURL = process.env.DOMAIN;
   const { priceId } = req.body;
 
+  // This is the ID of the Stripe Customer. Typically this is stored
+  // in your database and retrieved with the authenticated user.
+  //
+  // Note: The customer ID isn't required to start a Subscription, however
+  // it can be passed as an argument when creating a Checkout Session which
+  // associates the new Subscription with an existing Customer.
+  const stripeCustomerId = process.env.CUSTOMER;
+
   // Create new Checkout Session for the order
   // Other optional params include:
   // [billing_address_collection] - to display billing address details on the page
@@ -54,7 +62,7 @@ app.post("/create-checkout-session", async (req, res) => {
       // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
       success_url: `${domainURL}/success.html?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${domainURL}/canceled.html`,
-      customer: process.env.CUSTOMER,
+      customer: stripeCustomerId,
     });
 
     res.send({
@@ -79,9 +87,17 @@ app.get("/setup", (req, res) => {
 });
 
 app.post('/customer-portal', async (req, res) => {
+  // This is the ID of the Stripe Customer. Typically, this is stored alongside
+  // your authenticated user in the database.
+  const stripeCustomerId = process.env.CUSTOMER;
+
+  // This is the url to which the customer will be redirected when they are done
+  // managign their billing with the portal.
+  const returnUrl = process.env.DOMAIN;
+
   const session = await stripe.billingPortal.sessions.create({
-    customer: process.env.CUSTOMER,
-    return_url: process.env.DOMAIN,
+    customer: stripeCustomerId,
+    return_url: returnUrl,
   });
   res.redirect(301, session.url);
 });

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -54,6 +54,7 @@ app.post("/create-checkout-session", async (req, res) => {
       // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
       success_url: `${domainURL}/success.html?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${domainURL}/canceled.html`,
+      customer: process.env.CUSTOMER,
     });
 
     res.send({
@@ -75,6 +76,14 @@ app.get("/setup", (req, res) => {
     basicPrice: process.env.BASIC_PRICE_ID,
     proPrice: process.env.PRO_PRICE_ID,
   });
+});
+
+app.post('/customer-portal', async (req, res) => {
+  const session = await stripe.billingPortal.sessions.create({
+    customer: process.env.CUSTOMER,
+    return_url: process.env.DOMAIN,
+  });
+  res.redirect(301, session.url);
 });
 
 // Webhook handler for asynchronous events.

--- a/server/php-slim/index.php
+++ b/server/php-slim/index.php
@@ -53,6 +53,13 @@ $app->post('/create-checkout-session', function(Request $request, Response $resp
   $domain_url = getenv('DOMAIN');
   $body = json_decode($request->getBody());
 
+  // This is the ID of the Stripe Customer. Typically, this is stored
+  // in your database and retrieved alongside the authenticated user.
+  //
+  // Note: The customer parameter is not required, however if passed
+  // will associate the new Subscription with an existing Customer.
+  $stripe_customer_id = getenv('CUSTOMER');
+
   // Create new Checkout Session for the order
   // Other optional params include:
   // [billing_address_collection] - to display billing address details on the page
@@ -60,7 +67,6 @@ $app->post('/create-checkout-session', function(Request $request, Response $resp
   // [payment_intent_data] - lets capture the payment later
   // [customer_email] - lets you prefill the email input in the form
   // For full details see https://stripe.com/docs/api/checkout/sessions/create
-
   // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
   try {
     $checkout_session = \Stripe\Checkout\Session::create([
@@ -72,7 +78,7 @@ $app->post('/create-checkout-session', function(Request $request, Response $resp
         'price' => $body->priceId,
         'quantity' => 1,
       ]],
-      'customer' => getenv('CUSTOMER'),
+      'customer' => $stripe_customer_id,
     ]);
   } catch (Exception $e) {
     return $response->withJson([
@@ -86,6 +92,15 @@ $app->post('/create-checkout-session', function(Request $request, Response $resp
 });
 
 $app->post('/customer-portal', function(Request $request, Response $response) {
+  // This is the ID of the Stripe Customer. Typically this is stored in your
+  // database and retrieved alongside the authenticated customer. For demonstration
+  // purposes we have stored this value in the environment variables.
+  $stripe_customer_id = getenv('CUSTOMER');
+
+  // This is the URL to which the user will be redirected after they have
+  // finished managing their billing in the portal.
+  $return_url = getenv('DOMAIN');
+
   $session = \Stripe\BillingPortal\Session::create([
     'customer' => getenv('CUSTOMER'),
     'return_url' => getenv('DOMAIN'),

--- a/server/php-slim/index.php
+++ b/server/php-slim/index.php
@@ -71,7 +71,8 @@ $app->post('/create-checkout-session', function(Request $request, Response $resp
       'line_items' => [[
         'price' => $body->priceId,
         'quantity' => 1,
-      ]]
+      ]],
+      'customer' => getenv('CUSTOMER'),
     ]);
   } catch (Exception $e) {
     return $response->withJson([
@@ -82,6 +83,14 @@ $app->post('/create-checkout-session', function(Request $request, Response $resp
   }
 
   return $response->withJson(array('sessionId' => $checkout_session['id']));
+});
+
+$app->post('/customer-portal', function(Request $request, Response $response) {
+  $session = \Stripe\BillingPortal\Session::create([
+    'customer' => getenv('CUSTOMER'),
+    'return_url' => getenv('DOMAIN'),
+  ]);
+  return $response->withRedirect($session->url);
 });
 
 $app->post('/webhook', function(Request $request, Response $response) {

--- a/server/php/README.md
+++ b/server/php/README.md
@@ -1,7 +1,7 @@
-# Using Checkout for a subscription with PHP 
+# Using Checkout for a subscription with PHP
 
 ## Requirements
-* PHP 
+* PHP
 
 ## How to run
 
@@ -11,10 +11,10 @@
 composer install
 ```
 
-2. Copy .config.ini.sample to .config.ini and replace with your Stripe API keys 
+2. Copy .config.ini.sample to .config.ini and replace with your Stripe API keys
 
 ```
-cp .config.ini.sample .config.ini
+cp config.ini.sample config.ini
 ```
 
 3. Run the server locally

--- a/server/php/config.ini.sample
+++ b/server/php/config.ini.sample
@@ -1,7 +1,7 @@
 stripe_secret_key = sk_test_1234
 stripe_publishable_key = pk_test_1234
 stripe_webhook_secret = whsec_1234
-domain = https://example.com/  
+domain = https://example.com/
 basic_price_id = price_123
 pro_price_id = price_456
-
+customer = cus_123abc

--- a/server/php/public/config.php
+++ b/server/php/public/config.php
@@ -2,4 +2,8 @@
 
 require_once 'shared.php';
 
-echo json_encode(['publishableKey' => $config['stripe_publishable_key'], 'basicPrice' => $config['basic_price_id'], 'proPrice' => $config['pro_price_id']]);
+echo json_encode([
+  'publishableKey' => $config['stripe_publishable_key'],
+  'basicPrice' => $config['basic_price_id'],
+  'proPrice' => $config['pro_price_id']
+]);

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -3,7 +3,15 @@
 require_once 'shared.php';
 
 $domain_url = $config['domain'];
+
+// The ID of the Stripe Customer. This typically stored in your database
+// and retrieve alongside the authenticated user. For demonstration, we're
+// storing in the config variables.
+//
+// Note: This is not strictly required to create a Subscription. If passed,
+// it will associate the new Subscription with the existing Customer.
 $stripe_customer_id = $config['customer'];
+
 // Create new Checkout Session for the order
 // Other optional params include:
 // [billing_address_collection] - to display billing address details on the page

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -3,6 +3,7 @@
 require_once 'shared.php';
 
 $domain_url = $config['domain'];
+$stripe_customer_id = $config['customer'];
 // Create new Checkout Session for the order
 // Other optional params include:
 // [billing_address_collection] - to display billing address details on the page
@@ -20,7 +21,8 @@ $checkout_session = \Stripe\Checkout\Session::create([
 	'line_items' => [[
 	  'price' => $body->priceId,
 	  'quantity' => 1,
-	]]
+  ]],
+  'customer' => $stripe_customer_id,
 ]);
-  
+
 echo json_encode(['sessionId' => $checkout_session['id']]);

--- a/server/php/public/customer-portal.php
+++ b/server/php/public/customer-portal.php
@@ -1,0 +1,20 @@
+<?php
+
+require '../vendor/autoload.php';
+$config = parse_ini_file('../config.ini');
+
+if (!$config) {
+	http_response_code(500);
+	echo json_encode([ 'error' => 'Internal server error.' ]);
+	exit;
+}
+
+\Stripe\Stripe::setApiKey($config['stripe_secret_key']);
+
+$session = \Stripe\BillingPortal\Session::create([
+  'return_url' => $config['domain'],
+  'customer' => $config['customer'],
+]);
+
+header("Location: " . $session->url, true, 302);
+exit();

--- a/server/php/public/customer-portal.php
+++ b/server/php/public/customer-portal.php
@@ -11,9 +11,18 @@ if (!$config) {
 
 \Stripe\Stripe::setApiKey($config['stripe_secret_key']);
 
+// This is the ID of the Stripe Customer. Typically this is stored alongside
+// the authenticated user in your database. For demonstration, we're using the
+// config.
+$stripe_customer_id = $config['customer'];
+
+// This is the URL to which users are redirected after managing their billing
+// with the customer portal.
+$return_url = $config['domain'];
+
 $session = \Stripe\BillingPortal\Session::create([
-  'return_url' => $config['domain'],
-  'customer' => $config['customer'],
+  'customer' => $stripe_customer_id,
+  'return_url' => $return_url,
 ]);
 
 header("Location: " . $session->url, true, 302);

--- a/server/php/public/success.html
+++ b/server/php/public/success.html
@@ -25,12 +25,15 @@
           <div class="sr-section completed-view">
             <div class="sr-callout">
               <pre>
-    
+
               </pre>
             </div>
             <button onclick="window.location.href = '/';">Restart demo</button>
-          </div> 
-        </div> 
+            <form action="/customer-portal.php" method="post">
+              <button>Manage Billing</button>
+            </form>
+          </div>
+        </div>
         <div class="sr-content">
         <div class="pasha-image-stack">
           <img

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -51,6 +51,14 @@ def create_checkout_session():
     data = json.loads(request.data)
     domain_url = os.getenv('DOMAIN')
 
+    # This is the Stripe Customer ID. Typically, it's stored in your database
+    # and is retrieved alongside the authenticated user. For demonstration,
+    # we're storing in the environment variable.
+    # Note: The customer parameter is not strictly required for creating a
+    # Subscription with Checkout. If passed, the new Subscription will be associated
+    # with the existing Customer.
+    stripe_customer_id = os.getenv("CUSTOMER")
+
     try:
         # Create new Checkout Session for the order
         # Other optional params include:
@@ -72,7 +80,7 @@ def create_checkout_session():
                     "quantity": 1
                 }
             ],
-            customer=os.getenv("CUSTOMER"),
+            customer=stripe_customer_id,
         )
         return jsonify({'sessionId': checkout_session['id']})
     except Exception as e:
@@ -81,9 +89,21 @@ def create_checkout_session():
 
 @app.route('/customer-portal', methods=['POST'])
 def customer_portal():
+    # This is the Stripe Customer ID. Typically, it's stored in your database
+    # and is retrieved alongside the authenticated user. For demonstration,
+    # we're storing in the environment variable.
+    # Note: The customer parameter is not strictly required for creating a
+    # Subscription with Checkout. If passed, the new Subscription will be associated
+    # with the existing Customer.
+    stripe_customer_id = os.getenv("CUSTOMER")
+
+    # This is the URL to which the customer will be redirected after they are
+    # done managing their billing with the portal.
+    return_url = os.getenv("DOMAIN")
+
     session = stripe.billing_portal.Session.create(
-        customer=os.getenv("CUSTOMER"),
-        return_url=os.getenv("DOMAIN"))
+        customer=stripe_customer_id,
+        return_url=return_url)
     return redirect(session.url, 302)
 
 

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -10,7 +10,7 @@ import stripe
 import json
 import os
 
-from flask import Flask, render_template, jsonify, request, send_from_directory
+from flask import Flask, render_template, jsonify, request, send_from_directory, redirect
 from dotenv import load_dotenv, find_dotenv
 
 # Setup Stripe python client library
@@ -71,11 +71,20 @@ def create_checkout_session():
                     "price": data['priceId'],
                     "quantity": 1
                 }
-            ]
+            ],
+            customer=os.getenv("CUSTOMER"),
         )
         return jsonify({'sessionId': checkout_session['id']})
     except Exception as e:
         return jsonify({'error': {'message': str(e)}}), 400
+
+
+@app.route('/customer-portal', methods=['POST'])
+def customer_portal():
+    session = stripe.billing_portal.Session.create(
+        customer=os.getenv("CUSTOMER"),
+        return_url=os.getenv("DOMAIN"))
+    return redirect(session.url, 302)
 
 
 @app.route('/webhook', methods=['POST'])

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -55,7 +55,13 @@ post '/create-checkout-session' do
       line_items: [{
         quantity: 1,
         price: data['priceId'],
-      }]
+      }],
+
+      # This is the ID of the Stripe Customer object.  Typically you'll create
+      # the Stripe Customer when a new user registers for your application and
+      # you'll store their ID in your database. Here you can pass that ID along
+      # to associate checkout sessions with a given customer.
+      customer: ENV['CUSTOMER'],
     )
   rescue => e
     halt 400,
@@ -66,6 +72,14 @@ post '/create-checkout-session' do
   {
     sessionId: session.id
   }.to_json
+end
+
+post '/customer-portal' do
+  session = Stripe::BillingPortal::Session.create({
+    customer: ENV['CUSTOMER'],
+    return_url: ENV['DOMAIN'],
+  })
+  redirect session.url, 302
 end
 
 post '/webhook' do

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -38,6 +38,15 @@ end
 post '/create-checkout-session' do
   content_type 'application/json'
   data = JSON.parse(request.body.read)
+
+  # This is the ID of the Stripe Customer object.  Typically you'll create the
+  # Stripe Customer when a new user registers for your application and you'll
+  # store their ID in your database. Here you can pass that ID along to
+  # associate checkout sessions with a given customer. Note that it's not
+  # strictly required, but is useful for associating a Subscription to an
+  # existing Customer.
+  stripe_customer_id = ENV['CUSTOMER']
+
   # Create new Checkout Session for the order
   # Other optional params include:
   # [billing_address_collection] - to display billing address details on the page
@@ -56,12 +65,7 @@ post '/create-checkout-session' do
         quantity: 1,
         price: data['priceId'],
       }],
-
-      # This is the ID of the Stripe Customer object.  Typically you'll create
-      # the Stripe Customer when a new user registers for your application and
-      # you'll store their ID in your database. Here you can pass that ID along
-      # to associate checkout sessions with a given customer.
-      customer: ENV['CUSTOMER'],
+      customer: stripe_customer_id
     )
   rescue => e
     halt 400,
@@ -75,9 +79,19 @@ post '/create-checkout-session' do
 end
 
 post '/customer-portal' do
+  # This is the ID of the Stripe Customer. Typically it's stored in your database
+  # and retrieved alongside the authenticated user.
+  #
+  # For example, in Rails, you might use something like `current_user.stripe_customer_id`
+  stripe_customer_id = ENV['CUSTOMER']
+
+  # This is the URL to which users will be redirected after they are done
+  # managing their billing.
+  return_url = ENV['DOMAIN']
+
   session = Stripe::BillingPortal::Session.create({
-    customer: ENV['CUSTOMER'],
-    return_url: ENV['DOMAIN'],
+    customer: stripe_customer_id,
+    return_url: return_url,
   })
   redirect session.url, 302
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -29,5 +29,10 @@ RSpec.describe 'server APIs' do
     expect(status).to eq(200)
     expect(resp2).to have_key('id')
     expect(resp2['id']).to eq(resp['sessionId'])
+
+    # Create customer portal session
+    loc, status = post_json('/customer-portal', {})
+    expect(status).to eq(302)
+    expect(loc).to_not be_nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,7 +119,13 @@ end
 def post_json(path, payload, **kwargs)
   puts "Posting json to #{path}"
   defaults = {content_type: :json}
-  response = RestClient.post("#{SERVER_URL}#{path}", payload.to_json, defaults.merge(**kwargs))
+  response = RestClient.post("#{SERVER_URL}#{path}", payload.to_json, defaults.merge(**kwargs)) do |res, req, result, &blk|
+    if [301, 302, 307].include? res.code
+      return [res.headers[:location], res.code]
+    else
+      res.return!(&blk)
+    end
+  end
   [JSON.parse(response.body), response.code]
 rescue => e
   [JSON.parse(e.http_body), e.http_code]


### PR DESCRIPTION
cc @tmarek-stripe @jrondeau-stripe @dawn-stripe 

This PR adds support for a customer portal integration as part of this sample. I don't think we need separate samples for creating a subscription and managing them.

The big question is around where we store the ID of the customer for demonstration purposes. I'm in favor of keeping it in environment variables and we already have this expectation about price IDs. 

Curious thoughts around this in general as we'd like to write some docs for Checkout + Customer Portal and make that the default path. 