### PR TITLE
Bump stripe-node version from 7.1.0 to 8.107.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,18 @@
 {
-    "name": "stripe-sample-checkout-single-subscription",
-    "version": "1.0.0",
-    "description": "Subscription page with Checkout",
-    "main": "server.js",
-    "scripts": {
-      "start": "node client-and-server/server/node/server.js",
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "author": "stripe-samples",
-    "license": "ISC",
-    "dependencies": {
-      "body-parser": "^1.19.0",
-      "dotenv": "^8.0.0",
-      "express": "^4.17.1",
-      "stripe": "^7.1.0"
-    }
+  "name": "stripe-sample-checkout-single-subscription",
+  "version": "1.0.0",
+  "description": "Subscription page with Checkout",
+  "main": "server.js",
+  "scripts": {
+    "start": "node client-and-server/server/node/server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "stripe-samples",
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "dotenv": "^8.0.0",
+    "express": "^4.17.1",
+    "stripe": "^8.107.0"
   }
-  
+}


### PR DESCRIPTION
r? @cjavilla-stripe 

I did a test run setting up https://github.com/stripe-samples/checkout-single-subscription and took notes (happy to share via slack).

Anyway, the Customer Portal integration [you added](https://github.com/stripe-samples/checkout-single-subscription/pull/23) was super useful - once I got it working, it was really quick and didn't require extra steps.

However, I ran into one issue - this code:

https://github.com/stripe-samples/checkout-single-subscription/blob/master/server/node/server.js#L89-L96

failed, because I ran `npm install` at the root of the repo, and the package.json there specifies a very old version of stripe-node.

This PR bumps stripe-node to the latest version in the package.json at the root level to fix that issue and hopefully saves some debugging time for other folks.
