### PR TITLE
Small improvements to the node server and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ git clone https://github.com/stripe-samples/checkout-single-subscription
 Copy the `.env.example` file into a file named `.env` in the folder of the server you want to use. For example:
 
 ```
-cp .env.example client-and-server/server/node/.env
+cp .env.example server/node/.env
 ```
 
 You will need a Stripe account in order to run the demo. Once you set up your account, go to the Stripe [developer dashboard](https://stripe.com/docs/development/quickstart#api-keys) to find your API keys.
@@ -101,7 +101,7 @@ Pick the server language you want and follow the instructions in the server fold
 For example, if you want to run the Node server:
 
 ```
-cd client-and-server/server/node # there's a README in this folder with instructions
+cd server/node # there's a README in this folder with instructions
 npm install
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Subscription page with Checkout",
   "main": "server.js",
   "scripts": {
-    "start": "node client-and-server/server/node/server.js",
+    "start": "node server/node/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "stripe-samples",

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -3,7 +3,7 @@ const app = express();
 const path = require('path');
 
 // Copy the .env.example in the root into a .env file in this folder
-const envFilePath = path.resolve('./.env');
+const envFilePath = path.resolve(__dirname, './.env');
 const env = require("dotenv").config({ path: envFilePath });
 if (env.error) {
   throw new Error(`Unable to load the .env file from ${envFilePath}. Please copy .env.example to ${envFilePath}`);

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -1,9 +1,14 @@
 const express = require("express");
 const app = express();
-const { resolve } = require("path");
-// Copy the .env.example in the root into a .env file in this folder
+const path = require('path');
 
-const env = require("dotenv").config({ path: "./.env" });
+// Copy the .env.example in the root into a .env file in this folder
+const envFilePath = path.resolve('./.env');
+const env = require("dotenv").config({ path: envFilePath });
+if (env.error) {
+  throw new Error(`Unable to load the .env file from ${envFilePath}. Please copy .env.example to ${envFilePath}`);
+}
+
 const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 
 app.use(express.static(process.env.STATIC_DIR));
@@ -20,8 +25,8 @@ app.use(
 );
 
 app.get("/", (req, res) => {
-  const path = resolve(process.env.STATIC_DIR + "/index.html");
-  res.sendFile(path);
+  const filePath = path.resolve(process.env.STATIC_DIR + "/index.html");
+  res.sendFile(filePath);
 });
 
 // Fetch the Checkout Session to display the JSON result on the success page

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -137,4 +137,4 @@ app.post("/webhook", async (req, res) => {
   res.sendStatus(200);
 });
 
-app.listen(4242, () => console.log(`Node server listening on port ${4242}!`));
+app.listen(4242, () => console.log(`Node server listening at http://localhost:${4242}/`));


### PR DESCRIPTION
r? @cjavilla-stripe

As mentioned earlier, I did a test run setting up https://github.com/stripe-samples/checkout-single-subscription and took notes (happy to share via slack).

One of the issues I noted was that I had some difficulties getting the example to run because I wasn't sure where to place the env file. 

This PR makes a number of small tweaks to hopefully make that easier:

**Updates readme.md and package.json to no longer refer to client-and-server**

Updates readme.md and package.json to no longer contain references to the `client-and-server` subdirectory (since I think that was removed in https://github.com/stripe-samples/checkout-single-subscription/pull/20)

**Improves `.env` file loading and error message in the node server**

Before this PR, the node example server was loading the `.env` file like this:

```js
// Copy the .env.example in the root into a .env file in this folder
const env = require("dotenv").config({ path: "./.env" });
```

Reading the `dotenv` package ([here](https://github.com/motdotla/dotenv/blob/master/lib/main.js#L77-L110)) this means basically that we will be attempting to load `process.cwd() + './.env'` which means that the location where we are looking for the .env file depends on the current working directory, e.g. where the user invokes `npm start` from.

This does not match what the comment in the file (or what the readme.md says). 

According to the comment just above the line in server.js, users should "Copy the .env.example in the root into a .env file in this folder"

but if we are loading from `process.cwd() + './.env'`, then we aren't consistently looking for the `.env` file in the same folder as `server.js` because the path is resolved relative to the working directory, e.g. where the user invokes `npm start` from.

To fix this, I changed the loading to:

```js
// Copy the .env.example in the root into a .env file in this folder
const envFilePath = path.resolve(__dirname, './.env');
const env = require("dotenv").config({ path: envFilePath });
```

... this ensures that we are always looking for `.env` in the same folder the `server.js` file is in.

I also added a better error message that explicitly includes the path we are trying the load the `.env` file:

```js
if (env.error) {
  throw new Error(`Unable to load the .env file from ${envFilePath}. Please copy .env.example to ${envFilePath}`);
}
```

**Small improvement to the message logged when the server starts**

I changed the message logged after the server starts to include a URL so folks can just click it in their terminal vs. having to type in the localhost address.

