### PR TITLE
Better error logging on the client side

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -1,3 +1,15 @@
+// If a fetch error occurs, log it to the console
+var handleFetchResult = function(result) {
+  if (!result.ok) {
+    return result.json().then(function(json) {
+      if (json.error && json.error.message) {
+        throw new Error(result.url + ' ' + result.status + ' ' + json.error.message);
+      }
+    });
+  }
+  return result.json();
+};
+
 // Create a Checkout Session with the selected plan ID
 var createCheckoutSession = function(priceId) {
   return fetch("/create-checkout-session", {
@@ -8,9 +20,7 @@ var createCheckoutSession = function(priceId) {
     body: JSON.stringify({
       priceId: priceId
     })
-  }).then(function(result) {
-    return result.json();
-  });
+  }).then(handleFetchResult);
 };
 
 // Handle any errors returned from Checkout
@@ -23,9 +33,7 @@ var handleResult = function(result) {
 
 /* Get your Stripe publishable key to initialize Stripe.js */
 fetch("/setup")
-  .then(function(result) {
-    return result.json();
-  })
+  .then(handleFetchResult)
   .then(function(json) {
     var publishableKey = json.publishableKey;
     var basicPriceId = json.basicPrice;


### PR DESCRIPTION
r? @cjavilla-stripe

As mentioned earlier, I did a test run setting up https://github.com/stripe-samples/checkout-single-subscription and took notes (happy to share via slack).

One of the issues I noticed was that if I didn't fill in all the values in `.env`, the errors I got on the client side were a bit misleading because we were not logging all the errors.

This PR adds a bit more error handling to `client.js`, resulting in better error messages when an error occurs when fetching `/setup` or `/create-checkout-session`.

Error before:

<img width="823" alt="Screen Shot 2020-10-07 at 10 54 26 AM" src="https://user-images.githubusercontent.com/23064948/95379641-82f4d000-089a-11eb-9de8-266819a42f5b.png">

Error after:

<img width="803" alt="Screen Shot 2020-10-07 at 10 54 15 AM" src="https://user-images.githubusercontent.com/23064948/95379668-8ab47480-089a-11eb-90fe-081bca960e09.png">

