### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI for stripe-samples/checkout-single-subscription
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # repository: 'stripe-samples/checkout-single-subscription'
+          repository: 'hibariya/checkout-single-subscription'
+          ref: 'ci'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'stripe-samples/sample-ci'
+          path: 'sample-ci'
+          ref: 'ci'
+
+      - name: Install gettext for envsubst
+        run: |
+          sudo apt install gettext-base
+
+      - name: Install jq
+        run: |
+          sudo curl -o /usr/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          sudo chmod +x /usr/bin/jq
+
+      - name: Run tests
+        run: |
+          source sample-ci/helpers.sh
+
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=http://web:4242
+          BASIC_PRICE_ID=${BASIC}
+          PRO_PRICE_ID=${PREMIUM}
+          EOF
+
+          for lang in $(cat .cli.json | server_langs_for_integration main)
+          do
+            [ "$lang" = "php" ] && continue
+
+            configure_docker_compose_for_integration . "$lang" ../../client \
+                                                     target/single-subscription-checkout-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+
+            docker-compose up -d && wait_web_server
+            docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
+          done
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+          PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
+          BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,15 @@ jobs:
           STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
           PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
           BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw
+
+      - name: Collect debug information
+        if: ${{ failure() }}
+        run: |
+          cat docker-compose.yml
+          docker-compose ps -a
+          docker-compose logs web
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+          PREMIUM: price_1HXyXwCWW2eVYDoPnnTQ02VO
+          BASIC: price_1HXyVBCWW2eVYDoPtXcEdXfw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # repository: 'stripe-samples/checkout-single-subscription'
-          repository: 'hibariya/checkout-single-subscription'
-          ref: 'ci'
+          repository: 'stripe-samples/checkout-single-subscription'
 
       - uses: actions/checkout@v2
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: 'ci'
 
       - name: Install gettext for envsubst
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'rspec'
+gem 'rest-client'
+gem 'byebug'
+gem 'stripe'
+gem 'dotenv'

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -29,7 +29,7 @@ func main() {
 	http.HandleFunc("/checkout-session", handleCheckoutSession)
 	http.HandleFunc("/customer-portal", handleCustomerPortal)
 	http.HandleFunc("/webhook", handleWebhook)
-	addr := "localhost:4242"
+	addr := "0.0.0.0:4242"
 	log.Printf("Listening on %s ...", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }
@@ -123,8 +123,8 @@ func handleCustomerPortal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For demonstration purposes, we're using the Checkout session to retrieve the customer ID. 
-	// Typically this is stored alongside the authenticated user in your database. 
+	// For demonstration purposes, we're using the Checkout session to retrieve the customer ID.
+	// Typically this is stored alongside the authenticated user in your database.
 	sessionID := req.SessionID
 	s, _ := session.Get(sessionID, nil)
 

--- a/server/php-slim/composer.json
+++ b/server/php-slim/composer.json
@@ -6,6 +6,6 @@
         "monolog/monolog": "^1.17"
     },
     "scripts": {
-        "start": "php -S localhost:4242 index.php"
+        "start": "php -S 0.0.0.0:4242 index.php"
     }
 }

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -1,7 +1,6 @@
 require 'stripe'
 require 'sinatra'
 require 'dotenv'
-require 'byebug'
 
 # Copy the .env.example in the root into a .env file in this folder
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,4 +1,3 @@
-require './spec_helper.rb'
 require 'dotenv'
 Dotenv.load
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,7 +108,7 @@ end
 Dotenv.load
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
-SERVER_URL = "http://localhost:4242"
+SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')
 
 def get(path, *args, **kwargs)
   puts "Getting #{path}"


### PR DESCRIPTION
This is similar to https://github.com/stripe-samples/subscription-use-cases/pull/65. I added CI settings that ensure all server implementation can boot or pass existing tests. I also made some changes to run apps on Docker containers. You can confirm that a result of the workflow [here](https://github.com/hibariya/checkout-single-subscription/runs/1417743585?check_suite_focus=true).

Note that this PR needs the following PRs to be merged.

* https://github.com/stripe-samples/sample-ci/pull/1