### PR TITLE
Surface API errors on the client more prominently

### DIFF
--- a/client/css/global.css
+++ b/client/css/global.css
@@ -450,6 +450,19 @@ pre {
   text-align: center;
 }
 
+.error-message {
+  background-color: #000;
+  color: #fff;
+  display: none;
+  font-weight: bold;
+  left: 0;
+  padding: 10px;
+  position: fixed;
+  text-align: center;
+  top: 0;
+  width: 100%;
+}
+
 .completed-view-section {
   background-color: white;
   border-radius: 16px;

--- a/client/index.html
+++ b/client/index.html
@@ -46,8 +46,8 @@
             <button id="pro-plan-btn">Select</button>
           </section>
         </div>
-        <div id="error-message"></div>
       </div>
     </div>
+    <div id="error-message" class="error-message"></div>
   </body>
 </html>

--- a/client/script.js
+++ b/client/script.js
@@ -1,10 +1,13 @@
-// If a fetch error occurs, log it to the console
+// If a fetch error occurs, log it to the console and show it in the UI.
 var handleFetchResult = function(result) {
   if (!result.ok) {
     return result.json().then(function(json) {
       if (json.error && json.error.message) {
         throw new Error(result.url + ' ' + result.status + ' ' + json.error.message);
       }
+    }).catch(function(err) {
+      showErrorMessage(err);
+      throw err;
     });
   }
   return result.json();
@@ -26,9 +29,14 @@ var createCheckoutSession = function(priceId) {
 // Handle any errors returned from Checkout
 var handleResult = function(result) {
   if (result.error) {
-    var displayError = document.getElementById("error-message");
-    displayError.textContent = result.error.message;
+    showErrorMessage(result.error.message);
   }
+};
+
+var showErrorMessage = function(message) {
+  var errorEl = document.getElementById("error-message")
+  errorEl.textContent = message;
+  errorEl.style.display = "block";
 };
 
 /* Get your Stripe publishable key to initialize Stripe.js */


### PR DESCRIPTION
r? @cjavilla-stripe 
cc? @mikito-stripe

This change updates the UI to surface any errors returned from `fetch` calls both in the console and in the UI. It displays the error in a black banner pinned to the top of the screen (screenshot below).

This also updates the Go implementation to abide by the API the client expects, which specifies an `error` property on the response JSON that contains the corresponding error message.

![image](https://user-images.githubusercontent.com/74675829/100918610-b1f87e00-34a6-11eb-9abf-65655ed4fdd7.png)
