### PR TITLE
Use the same name to let CI run without passing the jar file path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI for stripe-samples/checkout-single-subscription
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI for stripe-samples/checkout-single-subscription
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          repository: 'stripe-samples/checkout-single-subscription'
 
       - uses: actions/checkout@v2
         with:
@@ -39,9 +37,7 @@ jobs:
           do
             [ "$lang" = "php" ] && continue
 
-            configure_docker_compose_for_integration . "$lang" ../../client \
-                                                     target/single-subscription-checkout-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration . "$lang" ../../client
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/server_spec.rb
           done

--- a/server/java/README.md
+++ b/server/java/README.md
@@ -11,7 +11,7 @@ mvn package
 
 2. Run the packaged jar
 ```
-java -cp target/single-subscription-checkout-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/server/java/pom.xml
+++ b/server/java/pom.xml
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As described in https://github.com/stripe-samples/sample-ci/pull/2, I changed the jar file names to the same one. 
