### PR TITLE
Typo fix in Python server comment link to documenation.

### DIFF
--- a/server/python/server.py
+++ b/server/python/server.py
@@ -63,7 +63,7 @@ def create_checkout_session():
         # [billing_address_collection] - to display billing address details on the page
         # [customer] - if you have an existing Stripe Customer ID
         # [customer_email] - lets you prefill the email input in the form
-        # For full details see https:#stripe.com/docs/api/checkout/sessions/create
+        # For full details see https://stripe.com/docs/api/checkout/sessions/create
 
         # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
         checkout_session = stripe.checkout.Session.create(


### PR DESCRIPTION
Replacing a `#` with `//` in `https://stripe.com/docs/api/checkout/sessions/create`