### PR TITLE
Include Stripe Tax Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,35 @@ stripe prices create \
   -d "recurring[interval]"=month
 ```
 
+<details>
+<summary>With Stripe Tax</summary>
+  Stripe Tax lets you calculate and collect sales tax, VAT and GST with one line of code.
+
+  Before creating a price, make sure you have Stripe Tax set up in the dashboard: [Docs - Set up Stripe Tax](https://stripe.com/docs/tax/set-up).
+
+  Stripe needs to know what kind of product you are selling to calculate the taxes. For this example we will submit a tax code describing what kind of product is used: `txcd_10000000` which is 'General - Electronically Supplied Services'. You can find a list of all tax codes here: [Available tax codes](https://stripe.com/docs/tax/tax-codes). If you leave the tax code empty, Stripe will use the default one from your [Tax settings](https://dashboard.stripe.com/test/settings/tax).
+
+  ```sh
+  stripe products create \
+    -d name="Premium" \
+    -d description="Premium plan" \
+    -d tax_code="txcd_10000000"
+  ```
+
+  From the response, copy the `id` and create a price. The tax behavior can be either `inclusive` or `exclusive`. For our example, we are using `exclusive`.
+
+  ```sh
+  stripe prices create \
+    -d unit_amount=1800 \
+    -d currency=usd \
+    -d tax_behavior=exclusive \
+    -d "recurring[interval]"=month \
+    -d product=<INSERT_ID, like prod_ABC123>
+  ```
+
+  More Information: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 **Using the Dashboard**
 
 You can create Products and Prices [in the dashboard](https://dashboard.stripe.com/products). Create two recurring Prices to run this sample.
@@ -117,7 +146,8 @@ Pick the server language you want and follow the instructions in the server fold
 For example, if you want to run the Node server:
 
 ```
-cd server/node # there's a README in this folder with instructions
+cd server/node
+# There's a README in this folder with instructions to run the server and how to enable Stripe Tax.
 npm install
 npm start
 ```

--- a/server/dotnet/Controllers/PaymentsController.cs
+++ b/server/dotnet/Controllers/PaymentsController.cs
@@ -51,6 +51,7 @@ namespace server.Controllers
                         Quantity = 1,
                     },
                 },
+                // AutomaticTax = new SessionAutomaticTaxOptions { Enabled = true },
             };
             var service = new SessionService(this.client);
             try

--- a/server/dotnet/README.md
+++ b/server/dotnet/README.md
@@ -1,4 +1,19 @@
-## Run with
+# Checkout single subscription - .NET
+
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`Controllers/PaymentsController.cs`](./Controllers/PaymentsController.cs) file you will find the following code commented out
+   ```csharp
+   // AutomaticTax = new SessionAutomaticTaxOptions { Enabled = true },
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
+## How to run
 
 ```sh
 dotnet run Program.cs

--- a/server/go/README.md
+++ b/server/go/README.md
@@ -1,4 +1,19 @@
-## Run with
+# Checkout single subscription - Go
+
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.go`](./server.go) file you will find the following code commented out
+   ```go
+   // AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{Enabled: stripe.Bool(true)},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
+## How to run
 
 ```sh
 go run server.go

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -77,6 +77,7 @@ func handleCreateCheckoutSession(w http.ResponseWriter, r *http.Request) {
 				Quantity: stripe.Int64(1),
 			},
 		},
+		// AutomaticTax: &stripe.CheckoutSessionAutomaticTaxParams{Enabled: stripe.Bool(true)},
 	}
 
 	s, err := session.New(params)

--- a/server/java/README.md
+++ b/server/java/README.md
@@ -4,6 +4,19 @@
 * Maven
 * Java
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`Server.java`](./src/main/java/com/stripe/sample/Server.java) file you will find the following code commented out
+   ```java
+   // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build())
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 1. Build the jar
 ```
 mvn package

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -71,6 +71,7 @@ public class Server {
             // [customer] - if you have an existing Stripe Customer ID
             // [payment_intent_data] - lets capture the payment later
             // [customer_email] - lets you prefill the email input in the form
+            // [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
             // For full details see https://stripe.com/docs/api/checkout/sessions/create
 
             // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID
@@ -85,6 +86,7 @@ public class Server {
                   .setPrice(request.queryParams("priceId"))
                   .build()
                 )
+                // .setAutomaticTax(SessionCreateParams.AutomaticTax.builder().setEnabled(true).build()).
                 .build();
 
             try {

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -13,6 +13,19 @@ An [Express server](http://expressjs.com) implementation
 npm install
 ```
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.js`](./server.js) file you will find the following code commented out
+   ```js
+   // automatic_tax: { enabled: true }
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 2. Run the application
 
 ```

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -53,6 +53,7 @@ app.post("/create-checkout-session", async (req, res) => {
   // [billing_address_collection] - to display billing address details on the page
   // [customer] - if you have an existing Stripe Customer ID
   // [customer_email] - lets you prefill the email input in the form
+  // [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
   // For full details see https://stripe.com/docs/api/checkout/sessions/create
   try {
     const session = await stripe.checkout.sessions.create({
@@ -67,6 +68,7 @@ app.post("/create-checkout-session", async (req, res) => {
       // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
       success_url: `${domainURL}/success.html?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${domainURL}/canceled.html`,
+      // automatic_tax: { enabled: true }
     });
 
     return res.redirect(303, session.url);

--- a/server/php/README.md
+++ b/server/php/README.md
@@ -5,6 +5,19 @@
 
 ## How to run
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`create-checkout-session.php`](./public/create-checkout-session.php) file you will find the following code commented out
+   ```php
+   // 'automatic_tax' => ['enabled' => true],
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 1. Run composer to set up dependencies
 
 ```

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -27,6 +27,7 @@ $domain_url = $_ENV['DOMAIN'];
 // [customer] - if you have an existing Stripe Customer ID
 // [payment_intent_data] - lets capture the payment later
 // [customer_email] - lets you prefill the email input in the form
+// [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
 // For full details see https://stripe.com/docs/api/checkout/sessions/create
 
 // ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
@@ -35,6 +36,7 @@ $checkout_session = \Stripe\Checkout\Session::create([
   'cancel_url' => $domain_url . '/canceled.php',
   'payment_method_types' => ['card'],
   'mode' => 'subscription',
+  // 'automatic_tax' => ['enabled' => true],
   'line_items' => [[
     'price' => $_POST['priceId'],
     'quantity' => 1,

--- a/server/python/README.md
+++ b/server/python/README.md
@@ -7,6 +7,19 @@
 
 ## How to run
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.py`](./server.py) file you will find the following code commented out
+   ```python
+   # automatic_tax={'enabled': True},
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 1. Create and activate a new virtual environment
 
 **MacOS / Unix**

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -63,6 +63,7 @@ def create_checkout_session():
         # [billing_address_collection] - to display billing address details on the page
         # [customer] - if you have an existing Stripe Customer ID
         # [customer_email] - lets you prefill the email input in the form
+        # [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
         # For full details see https://stripe.com/docs/api/checkout/sessions/create
 
         # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
@@ -71,6 +72,7 @@ def create_checkout_session():
             cancel_url=domain_url + '/canceled.html',
             payment_method_types=['card'],
             mode='subscription',
+            # automatic_tax={'enabled': True},
             line_items=[{
                 'price': price,
                 'quantity': 1

--- a/server/ruby/README.md
+++ b/server/ruby/README.md
@@ -8,6 +8,19 @@ A [Sinatra](http://sinatrarb.com/) implementation.
 
 ## How to run
 
+<details>
+<summary>Enabling Stripe Tax</summary>
+
+   In the [`server.rb`](./server.rb) file you will find the following code commented out
+   ```ruby
+   # automatic_tax: { enabled: true },
+   ```
+
+   Uncomment this line of code and the sales tax will be automatically calculated during the checkout.
+
+   Make sure you previously went through the set up of Stripe Tax: [Set up Stripe Tax](https://stripe.com/docs/tax/set-up) and you have your products and prices updated with tax behavior and optionally tax codes: [Docs - Update your Products and Prices](https://stripe.com/docs/tax/checkout#product-and-price-setup)
+</details>
+
 1. Install dependencies
 ```
 bundle install

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -49,6 +49,7 @@ post '/create-checkout-session' do
   # [billing_address_collection] - to display billing address details on the page
   # [customer] - if you have an existing Stripe Customer ID
   # [customer_email] - lets you prefill the email input in the form
+  # [automatic_tax] - to automatically calculate sales tax, VAT and GST in the checkout page
   # For full details see https://stripe.com/docs/api/checkout/sessions/create
   # ?session_id={CHECKOUT_SESSION_ID} means the redirect will have the session ID set as a query param
   begin
@@ -57,6 +58,7 @@ post '/create-checkout-session' do
       cancel_url: ENV['DOMAIN'] + '/canceled.html',
       payment_method_types: ['card'],
       mode: 'subscription',
+      # automatic_tax: { enabled: true },
       line_items: [{
         quantity: 1,
         price: params['priceId'],


### PR DESCRIPTION
## Summary

This Pull Request is really similar to the one here: [stripe-samples/checkout-one-time-payments/pull/150](https://github.com/stripe-samples/checkout-one-time-payments/pull/150).

I have included how customers can use Stripe Tax to automatically collect taxes in their checkout for subscriptions.

- Updated the `README.md` with the general set up flow, hidden below a dropdown. It explains how to create products and prices with additional properties that are needed for the automatic tax collection.
- Updated the `README.md` under each server's directory to showcase what has to be done to include Stripe Tax (simply uncomment a line of code)
- Wrote the line of code to enable Stripe Tax for each language's server and uncommented the line, so customers can enable it in an easy way

## Testing

I have tested each example manually and tax was shown when the line of code was uncommented.

## General

Thanks for using an `.env` file. It made testing a breeze 👍 

Another question: Do you think I should include a `.gif` on how the checkout looks with Stripe Tax enabled?

## Open Tasks

- N/A