### PR TITLE
Cancel in-progress CI runs when new one triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
@cjavilla-stripe This is the same as https://github.com/stripe-samples/accept-a-payment/pull/320