### PR TITLE
Fix failing tests and warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
           - server_type: dotnet
             server_image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'

--- a/server/ruby/config_helper.rb
+++ b/server/ruby/config_helper.rb
@@ -140,7 +140,7 @@ class ConfigHelper
       return false
     end
 
-    if !File.exists?(File.join(static_dir_path, 'index.html'))
+    if !File.exist?(File.join(static_dir_path, 'index.html'))
       if static_dir == ''
         puts <<~DOC
           No value set for STATIC_DIR. If this sample was installed with the
@@ -237,7 +237,7 @@ class ConfigHelper
   end
 
   def dotenv_exists?
-    return true if File.exists?("./.env")
+    return true if File.exist?("./.env")
 
     env_file_path = File.join(File.dirname(__FILE__), '.env')
     if !ENV['STRIPE_SECRET_KEY'] && !File.exist?("./.env")


### PR DESCRIPTION
I made a couple of changes to fix failing tests and warnings.

1. Update actions/checkout to the latest version (9c9ec7a25b737dd523607d096981c597e3f4801c): v2 had been causing deprecation warnings ([see also](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/))
2. File.exists? had been deprecated and removed from Ruby 3.1 (70e80ed425e2fc57841a720e03a20724d39f3fe9): updated to File.exist?
