### PR TITLE
Change CI workflow triggers to pull_request

### DIFF
--- a/.github/workflows/ci_server_dotnet.yml
+++ b/.github/workflows/ci_server_dotnet.yml
@@ -4,13 +4,10 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'server/dotnet/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_server_go.yml
+++ b/.github/workflows/ci_server_go.yml
@@ -4,13 +4,10 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'server/go/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_server_java.yml
+++ b/.github/workflows/ci_server_java.yml
@@ -4,13 +4,10 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'server/java/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_server_node.yml
+++ b/.github/workflows/ci_server_node.yml
@@ -4,13 +4,10 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'server/node/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_server_python.yml
+++ b/.github/workflows/ci_server_python.yml
@@ -4,13 +4,10 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'server/python/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:


### PR DESCRIPTION
### Summary

This PR removes the `pull_request_target` from the GitHub Action workflow triggers.

Right now, by using `pull_request_target`, the workflow executes off the targeted branch. That is, if we got a PR that's trying to merge code into `main`, then the CI tests would actually run off the existing `main` branch, which isn't what we want!

But we also can't easily use a different trigger like `pull_request`. The issue is that these CI checks are meant to run end-to-end tests, making live requests using a dedicated Stripe test account. And secrets (reasonably!) aren't available to pull requests from forked repositories.

In terms of benefit/risks tradeoffs, we decided that the preferred option is to just run these tests on pushes to the main branch. We have this today, so the only change to make here was to remove the `pull_request_target` trigger.

In the process, I also updated our `push` trigger to filter on the relevant paths to prevent unnecessary workflows from being executed.

### Rollout plan

After we merge this in, let's go have Dependabot rebase all the existing PR's / branches so everything is up-to-date.