### PR TITLE
Add reminders about security best practices and redact secrets in logs

### DIFF
--- a/.github/workflows/server_test.yml
+++ b/.github/workflows/server_test.yml
@@ -50,8 +50,8 @@ jobs:
         if: ${{ failure() }}
         run: |
           # Redact Stripe secret keys, restricted keys, and webhook secrets
-# before logging. Publishable keys (pk_) are safe to log.
-cat .env | sed 's/=\(sk_\|rk_\|whsec_\)[^[:space:]]*/=[REDACTED]/g'
+          # before logging. Publishable keys (pk_) are safe to log.
+          cat .env | sed 's/=\(sk_\|rk_\|whsec_\)[^[:space:]]*/=[REDACTED]/g'
           cat docker-compose.yml
           docker compose ps -a
           docker compose logs web

--- a/.github/workflows/server_test.yml
+++ b/.github/workflows/server_test.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Collect debug information
         if: ${{ failure() }}
         run: |
-          cat .env
+          # Redact Stripe secret keys, restricted keys, and webhook secrets
+# before logging. Publishable keys (pk_) are safe to log.
+cat .env | sed 's/=\(sk_\|rk_\|whsec_\)[^[:space:]]*/=[REDACTED]/g'
           cat docker-compose.yml
           docker compose ps -a
           docker compose logs web

--- a/server/dotnet/Program.cs
+++ b/server/dotnet/Program.cs
@@ -10,6 +10,11 @@ StripeConfiguration.AppInfo = new AppInfo
     Version = "0.0.1",
 };
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
 
 var builder = WebApplication.CreateBuilder(args);

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -22,6 +22,11 @@ func main() {
 		log.Fatalf("godotenv.Load: %v", err)
 	}
 
+	// Don't put any keys in code. Use an environment variable (as shown
+	// here) or secrets vault to supply keys to your integration.
+	//
+	// See https://docs.stripe.com/keys-best-practices and find your
+	// keys at https://dashboard.stripe.com/apikeys.
 	stripe.Key = os.Getenv("STRIPE_SECRET_KEY")
 	// For sample support and debugging, not required for production:
 	stripe.SetAppInfo(&stripe.AppInfo{

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -30,6 +30,11 @@ public class Server {
 
         Dotenv dotenv = Dotenv.load();
 
+        // Don't put any keys in code. Use an environment variable (as shown
+        // here) or secrets vault to supply keys to your integration.
+        //
+        // See https://docs.stripe.com/keys-best-practices and find your
+        // keys at https://dashboard.stripe.com/apikeys.
         Stripe.apiKey = dotenv.get("STRIPE_SECRET_KEY");
         // For sample support and debugging, not required for production:
         Stripe.setAppInfo(

--- a/server/nextjs/lib/stripe.ts
+++ b/server/nextjs/lib/stripe.ts
@@ -1,5 +1,10 @@
 import Stripe from "stripe";
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2025-12-15.clover",
   appInfo: {

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -9,6 +9,11 @@ if (env.error) {
   throw new Error(`Unable to load the .env file from ${envFilePath}. Please copy .env.example to ${envFilePath}`);
 }
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:

--- a/server/php/public/create-checkout-session.php
+++ b/server/php/public/create-checkout-session.php
@@ -12,6 +12,11 @@ $dotenv->load();
   "https://github.com/stripe-samples/checkout-single-subscription"
 );
 
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 \Stripe\Stripe::setApiKey($_ENV['STRIPE_SECRET_KEY']);
 
 if ($_SERVER['REQUEST_METHOD'] != 'POST') {

--- a/server/php/public/customer-portal.php
+++ b/server/php/public/customer-portal.php
@@ -11,6 +11,11 @@ $dotenv->load();
   "https://github.com/stripe-samples/checkout-single-subscription"
 );
 
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 \Stripe\Stripe::setApiKey($_ENV['STRIPE_SECRET_KEY']);
 
 if ($_SERVER['REQUEST_METHOD'] != 'POST') {

--- a/server/php/public/success.php
+++ b/server/php/public/success.php
@@ -3,6 +3,11 @@ require '../vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->load();
 
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 \Stripe\Stripe::setApiKey($_ENV['STRIPE_SECRET_KEY']);
 
 // Fetch the Checkout Session to display the JSON result on the success page

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -14,6 +14,11 @@ stripe.set_app_info(
     url='https://github.com/stripe-samples/checkout-single-subscription')
 
 stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
 static_dir = str(os.path.abspath(os.path.join(

--- a/server/ruby/config_helper.rb
+++ b/server/ruby/config_helper.rb
@@ -11,6 +11,11 @@ class ConfigHelper
     'PRO_PRICE_ID',
     'STATIC_DIR',
     'STRIPE_PUBLISHABLE_KEY',
+    # Don't put any keys in code. Use an environment variable (as shown
+    # here) or secrets vault to supply keys to your integration.
+    #
+    # See https://docs.stripe.com/keys-best-practices and find your
+    # keys at https://dashboard.stripe.com/apikeys.
     'STRIPE_SECRET_KEY',
     'STRIPE_WEBHOOK_SECRET',
   ]

--- a/server/ruby/config_helper.rb
+++ b/server/ruby/config_helper.rb
@@ -123,6 +123,14 @@ class ConfigHelper
     true
   end
 
+  def redact_key(key)
+    return '(unset)' if key.nil? || key == ''
+
+    return key[0, 4] + ('*' * (key.length - 4)) if key.length <= 14
+
+    "#{key[0, 8]}#{'*' * (key.length - 14)}#{key[-6..]}"
+  end
+
   def valid_paths?
     static_dir = ENV['STATIC_DIR']
     if static_dir.nil?
@@ -190,7 +198,7 @@ class ConfigHelper
         api_key: sk
       }).data.first
     rescue => e
-      puts "Failed testing an API request with your STRIPE_SECRET_KEY `#{sk}` check `.env`: \n\n#{e}"
+      puts "Failed testing an API request with your STRIPE_SECRET_KEY `#{redact_key(sk)}` check `.env`: \n\n#{e}"
       return false
     end
 

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -14,6 +14,11 @@ Stripe.set_app_info(
   url: 'https://github.com/stripe-samples/checkout-single-subscription'
 )
 Stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :static, true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,6 +106,11 @@ RSpec.configure do |config|
 end
 
 Dotenv.load
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')


### PR DESCRIPTION
## Summary

- Adds comments before `STRIPE_SECRET_KEY` assignments in all server files urging users not to put keys in code and pointing to [https://docs.stripe.com/keys-best-practices](https://docs.stripe.com/keys-best-practices).
- Replaces `cat .env` in CI workflow files with a redacting version that masks secret keys (`sk_`), restricted keys (`rk_`), and webhook secrets (`whsec_`) while leaving publishable keys visible.
- Where applicable (Ruby `config_helper.rb`): adds a `redact_key` helper and uses it in error messages so secret keys are not printed in full.